### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,4 +10,4 @@ services:
       - 8888:8888
     command: jupyter notebook --allow-root
     volumes:
-      .:/code
+      - .:/code


### PR DESCRIPTION
Fix for:

curt@green:~/ngfn_simulation_recon/docker-octave-jupyter$ make up
docker-compose up
ERROR: The Compose file './docker-compose.yaml' is invalid because:
services.octave-jupyter.volumes contains an invalid type, it should be an array
Makefile:11: recipe for target 'up' failed
make: *** [up] Error 1

curt@green:~$ docker-compose version
docker-compose version 1.25.4, build 8d51620a
docker-py version: 4.1.0
CPython version: 3.7.5
OpenSSL version: OpenSSL 1.1.0l  10 Sep 2019